### PR TITLE
T 61 settingspanel with footer

### DIFF
--- a/src/__tests__/utils/TestUtils.tsx
+++ b/src/__tests__/utils/TestUtils.tsx
@@ -24,8 +24,8 @@ export const callAndCheckDispatchCalls = async (callback: (dispatch: AppDispatch
   },
   settings: {
     alwaysInsertFullText: false,
-    favoritesHoisting: true,
-    favoritesHiding: true
+    favoritesHiding: false,
+    favoritesHoisting: false
   }
 }) => {
   const getState = () => state;

--- a/src/__tests__/utils/TestUtils.tsx
+++ b/src/__tests__/utils/TestUtils.tsx
@@ -23,7 +23,9 @@ export const callAndCheckDispatchCalls = async (callback: (dispatch: AppDispatch
     title: ""
   },
   settings: {
-    alwaysInsertFullText: false
+    alwaysInsertFullText: false,
+    favoritesHoisting: true,
+    favoritesHiding: true
   }
 }) => {
   const getState = () => state;

--- a/src/components/settingspanel/SettingsPanel.tsx
+++ b/src/components/settingspanel/SettingsPanel.tsx
@@ -38,7 +38,7 @@ export const SettingsPanel: React.FunctionComponent = () => {
                 <SettingsToggle label={STRING_RESOURCES.settings.labels.favoritesHoisting} checked={favoritesHoisting} onChange={setFavoritesHoisting} />
                 <SettingsToggle label={STRING_RESOURCES.settings.labels.favoritesHiding} checked={favoritesHiding} onChange={setFavoritesHiding} />
                 <SettingsToggle label={STRING_RESOURCES.settings.labels.alwaysInsertFullText} checked={alwaysInsertFullText} onChange={setAlwaysInsertFullText} />
-                <DefaultButton onClick={dismissPanel}>Cancel</DefaultButton>
+                <DefaultButton onClick={dismissPanel}>{STRING_RESOURCES.settings.buttons.cancelText}</DefaultButton>
             </div>
         ),
         [dismissPanel, favoritesHoisting, favoritesHiding, alwaysInsertFullText],
@@ -46,7 +46,7 @@ export const SettingsPanel: React.FunctionComponent = () => {
 
     return (
         <div>
-            <DefaultButton onClick={openPanel} iconProps={{ iconName: 'Settings' }} aria-label={STRING_RESOURCES.settings.buttons.ariaLabel} />
+            <DefaultButton onClick={openPanel} iconProps={{ iconName: 'Settings' }} aria-label={STRING_RESOURCES.settings.buttons.settingsText} />
             <Panel
                 isOpen={isOpen}
                 onDismiss={dismissPanel}

--- a/src/components/settingspanel/SettingsPanel.tsx
+++ b/src/components/settingspanel/SettingsPanel.tsx
@@ -46,7 +46,7 @@ export const SettingsPanel: React.FunctionComponent = () => {
 
     return (
         <div>
-            <DefaultButton onClick={openPanel} iconProps={{ iconName: 'Settings' }} />
+            <DefaultButton onClick={openPanel} iconProps={{ iconName: 'Settings' }} aria-label={STRING_RESOURCES.settings.buttons.ariaLabel} />
             <Panel
                 isOpen={isOpen}
                 onDismiss={dismissPanel}

--- a/src/components/settingspanel/SettingsPanel.tsx
+++ b/src/components/settingspanel/SettingsPanel.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { DefaultButton } from '@fluentui/react/lib/Button';
+import { Panel } from '@fluentui/react/lib/Panel';
+import { useBoolean } from '@fluentui/react-hooks';
+import { useAppDispatch, useAppSelector } from "../../redux/hooks";
+import {
+    selectAlwaysInsertFullText, selectFavoritesHiding, selectFavoritesHoisting,
+    toggleAlwaysInsertFullText, toggleFavoritesHiding,
+    toggleFavoritesHoisting
+} from "../../redux/settings/settings.slice";
+import SettingsToggle from "./SettingsToggle";
+import STRING_RESOURCES from "./Strings";
+
+export const SettingsPanel: React.FunctionComponent = () => {
+    const dispatch = useAppDispatch();
+    const alwaysInsertFullText = useAppSelector(selectAlwaysInsertFullText);
+    const favoritesHoisting = useAppSelector(selectFavoritesHoisting);
+    const favoritesHiding = useAppSelector(selectFavoritesHiding);
+    const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
+
+    const setAlwaysInsertFullText = async () => {
+        await dispatch(toggleAlwaysInsertFullText());
+    }
+
+    const setFavoritesHoisting = () => {
+        dispatch(toggleFavoritesHoisting());
+    }
+
+    const setFavoritesHiding = () => {
+        dispatch(toggleFavoritesHiding());
+    }
+
+    // This panel doesn't actually save anything; the buttons are just an example of what
+    // someone might want to render in a panel footer.
+    const onRenderFooterContent = React.useCallback(
+        () => (
+            <div>
+                <SettingsToggle label={STRING_RESOURCES.settings.labels.favoritesHoisting} checked={favoritesHoisting} onChange={setFavoritesHoisting} />
+                <SettingsToggle label={STRING_RESOURCES.settings.labels.favoritesHiding} checked={favoritesHiding} onChange={setFavoritesHiding} />
+                <SettingsToggle label={STRING_RESOURCES.settings.labels.alwaysInsertFullText} checked={alwaysInsertFullText} onChange={setAlwaysInsertFullText} />
+                <DefaultButton onClick={dismissPanel}>Cancel</DefaultButton>
+            </div>
+        ),
+        [dismissPanel, favoritesHoisting, favoritesHiding, alwaysInsertFullText],
+    );
+
+    return (
+        <div>
+            <DefaultButton onClick={openPanel} iconProps={{ iconName: 'Settings' }} />
+            <Panel
+                isOpen={isOpen}
+                onDismiss={dismissPanel}
+                headerText="Settings"
+                closeButtonAriaLabel="Close"
+                onRenderFooterContent={onRenderFooterContent}
+                // Stretch panel content to fill the available height so the footer is positioned
+                // at the bottom of the page
+                isFooterAtBottom={true}
+            >
+            </Panel>
+        </div>
+    );
+};

--- a/src/components/settingspanel/SettingsToggle.tsx
+++ b/src/components/settingspanel/SettingsToggle.tsx
@@ -1,0 +1,15 @@
+import {Toggle} from "@fluentui/react";
+import * as React from "react";
+
+const SettingsToggle = ({ label, checked, onChange }) => {
+  return <div style={{ paddingLeft: '16px' }}>
+      <Toggle
+          label={label}
+          checked={checked}
+          onChange={onChange}
+          style={{ margin: '10px' }}
+      />
+  </div>
+};
+
+export default SettingsToggle;

--- a/src/components/settingspanel/SettingsToggle.tsx
+++ b/src/components/settingspanel/SettingsToggle.tsx
@@ -1,5 +1,6 @@
-import {Toggle} from "@fluentui/react";
+import { Toggle } from "@fluentui/react";
 import * as React from "react";
+import PropTypes from "prop-types";
 
 const SettingsToggle = ({ label, checked, onChange }) => {
   return <div style={{ paddingLeft: '16px' }}>
@@ -10,6 +11,12 @@ const SettingsToggle = ({ label, checked, onChange }) => {
           style={{ margin: '10px' }}
       />
   </div>
+};
+
+SettingsToggle.propTypes = {
+    checked: PropTypes.bool.isRequired,
+    label: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired
 };
 
 export default SettingsToggle;

--- a/src/components/settingspanel/Strings.ts
+++ b/src/components/settingspanel/Strings.ts
@@ -1,0 +1,11 @@
+const strings = {
+    settings: {
+        labels: {
+            favoritesHoisting: "Favorieten apart bovenaan tonen",
+            favoritesHiding: "Favorieten ook verbergen uit eigen categorie",
+            alwaysInsertFullText: "Altijd de volledige omschrijving invoegen"
+        }
+    }
+};
+
+export default strings;

--- a/src/components/settingspanel/Strings.ts
+++ b/src/components/settingspanel/Strings.ts
@@ -1,7 +1,8 @@
 const strings = {
     settings: {
         buttons: {
-            ariaLabel: "Settings"
+            cancelText: "Cancel",
+            settingsText: "Settings"
         },
         labels: {
             alwaysInsertFullText: "Altijd de volledige omschrijving invoegen",

--- a/src/components/settingspanel/Strings.ts
+++ b/src/components/settingspanel/Strings.ts
@@ -1,9 +1,12 @@
 const strings = {
     settings: {
+        buttons: {
+            ariaLabel: "Settings"
+        },
         labels: {
-            favoritesHoisting: "Favorieten apart bovenaan tonen",
+            alwaysInsertFullText: "Altijd de volledige omschrijving invoegen",
             favoritesHiding: "Favorieten ook verbergen uit eigen categorie",
-            alwaysInsertFullText: "Altijd de volledige omschrijving invoegen"
+            favoritesHoisting: "Favorieten apart bovenaan tonen"
         }
     }
 };

--- a/src/components/settingspanel/__tests__/SettingsPanel.spec.tsx
+++ b/src/components/settingspanel/__tests__/SettingsPanel.spec.tsx
@@ -1,0 +1,42 @@
+import { renderWithProviders } from "../../../__tests__/utils/TestUtils";
+import { initialState } from "../../../redux/store";
+import STRING_RESOURCES from "../Strings";
+import React from "react";
+import { SettingsPanel } from "../SettingsPanel";
+import { fireEvent } from "@testing-library/react";
+import {Toggle} from "@fluentui/react";
+import SettingsToggle from "../SettingsToggle";
+
+describe('SettingsPanel Test Suite', () => {
+    test('Initial render', () => {
+        const { getByLabelText } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
+
+        expect(getByLabelText(STRING_RESOURCES.settings.buttons.ariaLabel)).toBeInTheDocument();
+    });
+
+    test('Click on the settings button opens the panel', () => {
+        const { getByLabelText } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
+
+        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.buttons.ariaLabel));
+
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting)).toBeInTheDocument();
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHiding)).toBeInTheDocument();
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.alwaysInsertFullText)).toBeInTheDocument();
+    });
+
+    test('Toggle', () => {
+        const { getByLabelText } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
+
+        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.buttons.ariaLabel));
+
+        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting));
+
+        const favoritesHoistingToggle = getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting) as (typeof SettingsToggle);
+
+        expect(favoritesHoistingToggle.checked)
+
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting)).toBeInTheDocument();
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHiding)).toBeInTheDocument();
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.alwaysInsertFullText)).toBeInTheDocument();
+    });
+});

--- a/src/components/settingspanel/__tests__/SettingsPanel.spec.tsx
+++ b/src/components/settingspanel/__tests__/SettingsPanel.spec.tsx
@@ -3,40 +3,82 @@ import { initialState } from "../../../redux/store";
 import STRING_RESOURCES from "../Strings";
 import React from "react";
 import { SettingsPanel } from "../SettingsPanel";
-import { fireEvent } from "@testing-library/react";
-import {Toggle} from "@fluentui/react";
-import SettingsToggle from "../SettingsToggle";
+import { fireEvent } from '@testing-library/react';
 
 describe('SettingsPanel Test Suite', () => {
-    test('Initial render', () => {
+    test('initial render', () => {
         const { getByLabelText } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
 
-        expect(getByLabelText(STRING_RESOURCES.settings.buttons.ariaLabel)).toBeInTheDocument();
+        expect(getByLabelText(STRING_RESOURCES.settings.buttons.settingsText)).toBeInTheDocument();
     });
 
-    test('Click on the settings button opens the panel', () => {
-        const { getByLabelText } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
+    test('click on the settings button opens the panel', () => {
+        const { getByLabelText, getByText } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
 
-        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.buttons.ariaLabel));
+        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.buttons.settingsText));
 
         expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting)).toBeInTheDocument();
         expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHiding)).toBeInTheDocument();
         expect(getByLabelText(STRING_RESOURCES.settings.labels.alwaysInsertFullText)).toBeInTheDocument();
+        expect(getByText(STRING_RESOURCES.settings.buttons.cancelText)).toBeInTheDocument();
     });
 
-    test('Toggle', () => {
-        const { getByLabelText } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
+    test('favoritesHoisting is changed when toggle is clicked', () => {
+        const { getByLabelText, store } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
 
-        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.buttons.ariaLabel));
+        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.buttons.settingsText));
+
+        expect(store.getState().settings.favoritesHoisting).toBe(false);
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting)).not.toBeChecked();
 
         fireEvent.click(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting));
 
-        const favoritesHoistingToggle = getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting) as (typeof SettingsToggle);
+        expect(store.getState().settings.favoritesHoisting).toBe(true);
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting)).toBeChecked();
+    });
 
-        expect(favoritesHoistingToggle.checked)
+    test('favoritesHiding is changed when toggle is clicked', () => {
+        const { getByLabelText, store } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
+
+        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.buttons.settingsText));
+
+        expect(store.getState().settings.favoritesHiding).toBe(false);
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHiding)).not.toBeChecked();
+
+        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHiding));
+
+        expect(store.getState().settings.favoritesHiding).toBe(true);
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHiding)).toBeChecked();
+    });
+
+    test('alwaysInsertFullText is changed when toggle is clicked', () => {
+        const { getByLabelText, store } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
+
+        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.buttons.settingsText));
+
+        expect(store.getState().settings.alwaysInsertFullText).toBe(false);
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.alwaysInsertFullText)).not.toBeChecked();
+
+        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.labels.alwaysInsertFullText));
+
+        expect(store.getState().settings.alwaysInsertFullText).toBe(true);
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.alwaysInsertFullText)).toBeChecked();
+    });
+
+    test('click on the cancel button closes the panel', () => {
+        const { getByLabelText, getByText } = renderWithProviders(<SettingsPanel  />, { preloadedState: initialState });
+
+        fireEvent.click(getByLabelText(STRING_RESOURCES.settings.buttons.settingsText));
 
         expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting)).toBeInTheDocument();
         expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHiding)).toBeInTheDocument();
         expect(getByLabelText(STRING_RESOURCES.settings.labels.alwaysInsertFullText)).toBeInTheDocument();
+        expect(getByText(STRING_RESOURCES.settings.buttons.cancelText)).toBeInTheDocument();
+
+        fireEvent.click(getByText(STRING_RESOURCES.settings.buttons.cancelText));
+
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHoisting)).not.toBeVisible();
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.favoritesHiding)).not.toBeVisible();
+        expect(getByLabelText(STRING_RESOURCES.settings.labels.alwaysInsertFullText)).not.toBeVisible();
     });
 });

--- a/src/components/settingspanel/__tests__/SettingsToggle.spec.tsx
+++ b/src/components/settingspanel/__tests__/SettingsToggle.spec.tsx
@@ -1,0 +1,28 @@
+import { renderWithProviders } from "../../../__tests__/utils/TestUtils";
+import { initialState } from "../../../redux/store";
+import STRING_RESOURCES from "../Strings";
+import React from "react";
+import SettingsToggle from "../SettingsToggle";
+import {
+    selectAlwaysInsertFullText, selectFavoritesHiding, selectFavoritesHoisting,
+    toggleAlwaysInsertFullText, toggleFavoritesHiding,
+    toggleFavoritesHoisting
+} from "../../../redux/settings/settings.slice";
+import {useAppSelector} from "../../../redux/hooks";
+
+describe('SettingsToggle Test Suite', () => {
+    test('Initial render', () => {
+        const { getByText } = renderWithProviders(<SettingsToggle label={STRING_RESOURCES.settings.labels.favoritesHoisting} checked={true} onChange={() => false} />, { preloadedState: initialState });
+
+        expect(getByText(STRING_RESOURCES.settings.labels.favoritesHoisting)).toBeInTheDocument();
+    });
+
+    test('Toggle', () => {
+        const alwaysInsertFullText = useAppSelector(selectAlwaysInsertFullText);
+        const favoritesHoisting = useAppSelector(selectFavoritesHoisting);
+        const favoritesHiding = useAppSelector(selectFavoritesHiding);
+        const { getByText } = renderWithProviders(<SettingsToggle label={STRING_RESOURCES.settings.labels.favoritesHoisting} checked={true} onChange={() => false} />, { preloadedState: initialState });
+
+        expect(getByText(STRING_RESOURCES.settings.labels.favoritesHoisting)).toBeInTheDocument();
+    });
+});

--- a/src/components/settingspanel/__tests__/SettingsToggle.spec.tsx
+++ b/src/components/settingspanel/__tests__/SettingsToggle.spec.tsx
@@ -3,24 +3,9 @@ import { initialState } from "../../../redux/store";
 import STRING_RESOURCES from "../Strings";
 import React from "react";
 import SettingsToggle from "../SettingsToggle";
-import {
-    selectAlwaysInsertFullText, selectFavoritesHiding, selectFavoritesHoisting,
-    toggleAlwaysInsertFullText, toggleFavoritesHiding,
-    toggleFavoritesHoisting
-} from "../../../redux/settings/settings.slice";
-import {useAppSelector} from "../../../redux/hooks";
 
 describe('SettingsToggle Test Suite', () => {
     test('Initial render', () => {
-        const { getByText } = renderWithProviders(<SettingsToggle label={STRING_RESOURCES.settings.labels.favoritesHoisting} checked={true} onChange={() => false} />, { preloadedState: initialState });
-
-        expect(getByText(STRING_RESOURCES.settings.labels.favoritesHoisting)).toBeInTheDocument();
-    });
-
-    test('Toggle', () => {
-        const alwaysInsertFullText = useAppSelector(selectAlwaysInsertFullText);
-        const favoritesHoisting = useAppSelector(selectFavoritesHoisting);
-        const favoritesHiding = useAppSelector(selectFavoritesHiding);
         const { getByText } = renderWithProviders(<SettingsToggle label={STRING_RESOURCES.settings.labels.favoritesHoisting} checked={true} onChange={() => false} />, { preloadedState: initialState });
 
         expect(getByText(STRING_RESOURCES.settings.labels.favoritesHoisting)).toBeInTheDocument();

--- a/src/redux/settings/settings.slice.ts
+++ b/src/redux/settings/settings.slice.ts
@@ -3,7 +3,9 @@ import { createSlice } from "@reduxjs/toolkit";
 import { RootState } from "../store";
 
 export const initialState: SettingsState = {
-  alwaysInsertFullText: false
+  alwaysInsertFullText: false,
+  favoritesHoisting: false,
+  favoritesHiding: false
 }
 
 export const settingsSlice = createSlice({
@@ -12,12 +14,20 @@ export const settingsSlice = createSlice({
   reducers: {
     toggleAlwaysInsertFullText: (state) => {
       state.alwaysInsertFullText = !state.alwaysInsertFullText;
+    },
+    toggleFavoritesHoisting: (state) => {
+      state.favoritesHoisting = !state.favoritesHoisting;
+    },
+    toggleFavoritesHiding: (state) => {
+      state.favoritesHiding = !state.favoritesHiding;
     }
   }
 });
 
-export const { toggleAlwaysInsertFullText } = settingsSlice.actions;
+export const { toggleAlwaysInsertFullText, toggleFavoritesHoisting, toggleFavoritesHiding } = settingsSlice.actions;
 
 export const selectAlwaysInsertFullText = (state: RootState) => state.settings.alwaysInsertFullText;
+export const selectFavoritesHoisting = (state: RootState) => state.settings.favoritesHoisting;
+export const selectFavoritesHiding = (state: RootState) => state.settings.favoritesHiding;
 
 export default settingsSlice.reducer;

--- a/src/redux/settings/settings.slice.ts
+++ b/src/redux/settings/settings.slice.ts
@@ -4,8 +4,8 @@ import { RootState } from "../store";
 
 export const initialState: SettingsState = {
   alwaysInsertFullText: false,
-  favoritesHoisting: false,
-  favoritesHiding: false
+  favoritesHiding: false,
+  favoritesHoisting: false
 }
 
 export const settingsSlice = createSlice({
@@ -15,11 +15,11 @@ export const settingsSlice = createSlice({
     toggleAlwaysInsertFullText: (state) => {
       state.alwaysInsertFullText = !state.alwaysInsertFullText;
     },
-    toggleFavoritesHoisting: (state) => {
-      state.favoritesHoisting = !state.favoritesHoisting;
-    },
     toggleFavoritesHiding: (state) => {
       state.favoritesHiding = !state.favoritesHiding;
+    },
+    toggleFavoritesHoisting: (state) => {
+      state.favoritesHoisting = !state.favoritesHoisting;
     }
   }
 });

--- a/src/redux/settings/settings.types.ts
+++ b/src/redux/settings/settings.types.ts
@@ -1,3 +1,5 @@
 export interface SettingsState {
   alwaysInsertFullText: boolean;
+  favoritesHoisting: boolean;
+  favoritesHiding: boolean;
 }

--- a/src/taskpane/components/TaskPane.tsx
+++ b/src/taskpane/components/TaskPane.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { mergeStyleSets } from "@fluentui/react/lib/Styling";
 import { AddButton, CategoryComponent, Modal } from "../../components";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { selectData, selectIsLoading } from "../../redux/category/category.slice";
 import { loadData } from "../../middleware/category/CategoryMiddleware";
 import FreeFeedbackInput from "../../components/freefeedbackinput/FreeFeedbackInput";
-import { Toggle } from "@fluentui/react";
-import { selectAlwaysInsertFullText, toggleAlwaysInsertFullText } from "../../redux/settings/settings.slice";
+import { SettingsPanel } from "../../components/settingspanel/SettingsPanel";
+import {
+  selectFavoritesHiding,
+  selectFavoritesHoisting
+} from "../../redux/settings/settings.slice";
 
 const taskPaneClassNames = mergeStyleSets({
   fixedInputBox: {
@@ -40,12 +43,10 @@ const taskPaneClassNames = mergeStyleSets({
 
 const TaskPane: React.FC = () => {
   const dispatch = useAppDispatch();
-  const [favoritesHoistingEnabled, setFavoritesHoistingEnabled] = useState(true);
-  const [favoritesHidingEnabled, setFavoritesHidingEnabled] = useState(true);
-
+  const favoritesHoisting = useAppSelector(selectFavoritesHoisting);
+  const favoritesHiding = useAppSelector(selectFavoritesHiding);
   const categories = useAppSelector(selectData) || []; // Ensure categories is always an array
   const isLoading = useAppSelector(selectIsLoading);
-  const alwaysInsertFullText = useAppSelector(selectAlwaysInsertFullText);
 
   useEffect(() => {
     dispatch(loadData());
@@ -60,8 +61,8 @@ const TaskPane: React.FC = () => {
   };
 
   const processedCategories = categories.map(category => {
-    const filteredSubCategories = favoritesHoistingEnabled
-      ? category.subCategories.filter(sub => !favoritesHidingEnabled || !sub.isFavorite)
+    const filteredSubCategories = favoritesHoisting
+      ? category.subCategories.filter(sub => !favoritesHiding || !sub.isFavorite)
       : category.subCategories;
 
     return {
@@ -70,12 +71,8 @@ const TaskPane: React.FC = () => {
     };
   });
 
-  const setAlwaysInsertFullText = () => {
-    dispatch(toggleAlwaysInsertFullText());
-  }
-
 // only add favorites to special category if hoisting is enabled
-  if (favoritesHoistingEnabled) {
+  if (favoritesHoisting) {
     favoritesCategory.subCategories = categories.reduce((acc, category) => {
       const favSubCategories = category.subCategories.filter(sub => sub.isFavorite);
       return [...acc, ...favSubCategories];
@@ -93,29 +90,8 @@ const TaskPane: React.FC = () => {
       <div className={taskPaneClassNames.fixedInputBox}>
         <FreeFeedbackInput />
       </div>
-      <div style={{ paddingLeft: '16px' }}>
-        <Toggle
-          label="Favorieten apart bovenaan tonen"
-          checked={favoritesHoistingEnabled}
-          onChange={() => setFavoritesHoistingEnabled(!favoritesHoistingEnabled)}
-          style={{ margin: '10px' }}
-        />
-      </div>
-      <div style={{ paddingLeft: '16px' }}>
-        <Toggle
-          label="Favorieten ook verbergen uit eigen categorie"
-          checked={favoritesHidingEnabled}
-          onChange={() => setFavoritesHidingEnabled(!favoritesHidingEnabled)}
-          style={{ margin: '10px' }}
-        />
-      </div>
-      <div style={{ paddingLeft: '16px' }}>
-        <Toggle
-          label="Favorieten altijd als volledige tekst invoegen"
-          checked={alwaysInsertFullText}
-          onChange={setAlwaysInsertFullText}
-          style={{ margin: '10px' }}
-        />
+      <div>
+        <SettingsPanel />
       </div>
       <Modal />
       {isLoading ? (

--- a/src/types/SubCategory.ts
+++ b/src/types/SubCategory.ts
@@ -8,7 +8,6 @@ interface SubCategory {
   backgroundColor?: Nullable<string>;
   shortCode?: string;
   subSubCategories?: SubSubCategory[];
-  url?: string;
 }
 
 export default SubCategory;


### PR DESCRIPTION
![image](https://github.com/pxldigital-s2it/internship-wordtool-2324-team2/assets/114139877/65f4f3fd-b0e7-4ae9-a97e-73be8d7f3bd7)

Settings panel toegevoegd en alle settings functionaliteit naar redux verplaatst en aangeroepen vanuit de panel.

Tests toegevoegd, maar moeten misschien nagekeken worden.