### PR TITLE
Changed text to Dutch and removed the duplicate close button

### DIFF
--- a/src/components/settingspanel/SettingsPanel.tsx
+++ b/src/components/settingspanel/SettingsPanel.tsx
@@ -54,8 +54,8 @@ export const SettingsPanel: React.FunctionComponent = () => {
             <Panel
                 isOpen={isOpen}
                 onDismiss={dismissPanel}
-                headerText="Settings"
-                closeButtonAriaLabel="Close"
+                headerText={STRING_RESOURCES.settings.buttons.settingsText}
+                hasCloseButton={false}
                 onRenderFooterContent={onRenderFooterContent}
                 // Stretch panel content to fill the available height so the footer is positioned
                 // at the bottom of the page

--- a/src/components/settingspanel/Strings.ts
+++ b/src/components/settingspanel/Strings.ts
@@ -1,8 +1,8 @@
 const strings = {
     settings: {
         buttons: {
-            cancelText: "Cancel",
-            settingsText: "Settings"
+            cancelText: "Sluiten",
+            settingsText: "Instellingen"
         },
         labels: {
             alwaysInsertFullText: "Altijd de volledige omschrijving invoegen",


### PR DESCRIPTION
Alles staat nu in het Nederlands en het kruisje is weg. Escape om de panel te sluiten werkt standaard en enter lukt ook, maar er moet de tab key naar de "Sluiten" button gegaan worden.
![image](https://github.com/pxldigital-s2it/internship-wordtool-2324-team2/assets/114139877/6446ee21-d2ce-41f3-b157-e7558f71072c)
